### PR TITLE
Add interpolation to static heights

### DIFF
--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -662,8 +662,5 @@ def wrfout_seriesReader(wrfpath,wrfFileFilter,desiredHeights):
     ds_subset=ds_subset.rename_vars({'XLONG':'lon'})
     ds_subset=ds_subset.rename_vars({'XLAT':'lat'})
     ds_subset=ds_subset.rename_dims(dims_dict)
-                                                 'bottom_top':'nz',
-                                                 'south_north': 'ny',
-                                                 'west_east':'nx'})
     return ds_subset
 

--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -582,7 +582,7 @@ def extract_column_from_wrfdata(fpath, coords,
 
     return xn
 
-def wrfout_seriesReader(wrfpath,wrfFileFilter,desiredHeights):
+def wrfout_seriesReader(wrfpath,wrfFileFilter,desiredHeights=None):
     """
     Construct an a2e-mmc standard, xarrays-based, data structure from a
     series of 3-dimensional WRF output files

--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -607,7 +607,11 @@ def wrfout_seriesReader(wrfpath,wrfFileFilter,desiredHeights):
         'south_north': 'ny',
         'west_east':'nx',
     }
-    ds=xr.open_mfdataset(wrfpath+wrfFileFilter,chunks={'Time': 10},combine='nested',concat_dim='Time')
+
+    ds = xr.open_mfdataset(os.path.join(wrfpath,wrfFileFilter),
+                           chunks={'Time': 10},
+                           combine='nested',
+                           concat_dim='Time')
     dim_keys = ["Time","bottom_top","south_north","west_east"] 
     horiz_dim_keys = ["south_north","west_east"]
     print('Finished opening/concatenating datasets...')

--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -582,7 +582,7 @@ def extract_column_from_wrfdata(fpath, coords,
 
     return xn
 
-def wrfout_seriesReader(wrfpath,wrfFileFilter):
+def wrfout_seriesReader(wrfpath,wrfFileFilter,desiredHeights):
     """
     Construct an a2e-mmc standard, xarrays-based, data structure from a
     series of 3-dimensional WRF output files
@@ -596,6 +596,9 @@ def wrfout_seriesReader(wrfpath,wrfFileFilter):
         The path to directory containing wrfout files to be processed
     wrfFileFilter : string-glob expression
 	A string-glob expression to filter a set of 4-dimensional WRF output files.
+    desiredHeights : list-like
+        A list of static heights to which all data variables should be
+        interpolated.
     """
     TH0 = 300.0 #WRF convention base-state theta = 300.0 K
     dims_dict = {
@@ -632,11 +635,12 @@ def wrfout_seriesReader(wrfpath,wrfFileFilter):
     ds_subset['theta']=xr.DataArray(ds['THM']+TH0,dims=dim_keys)
 
     # interpolate to static heights
-    if desired_heights is not None:
+    if desiredHeights is not None:
         zarr = ds_subset['z']
         for var in ['u','v','w','p','theta']:
             print('Interpolating',var)
-            ds_subset[var] = wrf.interplevel(ds_subset[var], zarr, desired_heights).expand_dims('Time',axis=0)
+            interpolated = wrf.interplevel(ds_subset[var], zarr, desiredHeights)
+            ds_subset[var] = interpolated.expand_dims('Time', axis=0)
         ds_subset = ds_subset.drop_dims('bottom_top').rename({'level':'z'})
         dim_keys[1] = 'z'
         dims_dict.pop('bottom_top')
@@ -650,7 +654,7 @@ def wrfout_seriesReader(wrfpath,wrfFileFilter):
     
     #assign 'height' as a coordinate in the dataset
     ds_subset=ds_subset.rename({'XTIME': 'datetime'})  #Rename after defining the component DataArrays in the DataSet
-    if desired_heights is None:
+    if desiredHeights is None:
         ds_subset=ds_subset.assign_coords(z=ds_subset['z'])
     ds_subset=ds_subset.assign_coords(y=ds_subset['y'])
     ds_subset=ds_subset.assign_coords(x=ds_subset['x'])

--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -598,6 +598,12 @@ def wrfout_seriesReader(wrfpath,wrfFileFilter):
 	A string-glob expression to filter a set of 4-dimensional WRF output files.
     """
     TH0 = 300.0 #WRF convention base-state theta = 300.0 K
+    dims_dict = {
+        'Time':'datetime',
+        'bottom_top':'nz',
+        'south_north': 'ny',
+        'west_east':'nx',
+    }
     ds=xr.open_mfdataset(wrfpath+wrfFileFilter,chunks={'Time': 10},combine='nested',concat_dim='Time')
     dim_keys = ["Time","bottom_top","south_north","west_east"] 
     horiz_dim_keys = ["south_north","west_east"]
@@ -638,7 +644,7 @@ def wrfout_seriesReader(wrfpath,wrfFileFilter):
     ds_subset=ds_subset.assign_coords(zsurface=ds_subset['zsurface'])
     ds_subset=ds_subset.rename_vars({'XLONG':'lon'})
     ds_subset=ds_subset.rename_vars({'XLAT':'lat'})
-    ds_subset=ds_subset.rename_dims(dims_dict = {'Time':'datetime',
+    ds_subset=ds_subset.rename_dims(dims_dict)
                                                  'bottom_top':'nz',
                                                  'south_north': 'ny',
                                                  'west_east':'nx'})


### PR DESCRIPTION
After playing around with this for a while, it seems that `wrf.interplevels()` is the most efficient implementation. I've implemented an option in your `wrfout_seriesReader()` function that will do the heavy lifting. Feel free to rename 'desiredHeights' to something else (e.g., 'static_heights' or simply 'heights'). I've used camelCase to be consistent with your other input parameters, but in general I personally prefer the underscore format (consider: `read_wrfout()`). 

I also did some PEP8 standardization for a consistent look and feel throughout. (So it looks like I rewrote everything but most of the apparent edits are actually just from the last commit, see 9251885) 

The commits themselves should be relatively straightforward and self-explanatory--see the extended "..." commit messages for notes/additional comments.

Final note on performance: Your original code ran in 10s; specifying 'desiredHeights' increased the runtime to 50s. This was still an order of magnitude faster than any interpolation approach I could come up with.